### PR TITLE
perf: add `LazyComponent` for client code splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@floating-ui/react-dom-interactions": "^0.9.2",
     "@rehooks/local-storage": "^2.4.4",
     "@tanstack/react-query": "^4.0.10",
+    "@tanstack/react-query-devtools": "^4.2.1",
     "@tanstack/react-virtual": "3.0.0-beta.17",
     "echarts": "^5.3.3",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@floating-ui/react-dom-interactions': ^0.9.2
   '@rehooks/local-storage': ^2.4.4
   '@tanstack/react-query': ^4.0.10
+  '@tanstack/react-query-devtools': ^4.2.1
   '@tanstack/react-virtual': 3.0.0-beta.17
   '@types/lodash': ^4.14.182
   '@types/node': ^16
@@ -37,6 +38,7 @@ dependencies:
   '@floating-ui/react-dom-interactions': 0.9.2_biqbaboplfbrettd7655fr4n2y
   '@rehooks/local-storage': 2.4.4_react@18.2.0
   '@tanstack/react-query': 4.0.10_biqbaboplfbrettd7655fr4n2y
+  '@tanstack/react-query-devtools': 4.2.1_7osjxf5bgd7vybu7yx635kvpya
   '@tanstack/react-virtual': 3.0.0-beta.17_react@18.2.0
   echarts: 5.3.3
   lodash: 4.17.21
@@ -680,8 +682,30 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@tanstack/match-sorter-utils/8.1.1:
+    resolution: {integrity: sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==}
+    engines: {node: '>=12'}
+    dependencies:
+      remove-accents: 0.4.2
+    dev: false
+
   /@tanstack/query-core/4.0.10:
     resolution: {integrity: sha512-9LsABpZXkWZHi4P1ozRETEDXQocLAxVzQaIhganxbNuz/uA3PsCAJxJTiQrknG5htLMzOF5MqM9G10e6DCxV1A==}
+    dev: false
+
+  /@tanstack/react-query-devtools/4.2.1_7osjxf5bgd7vybu7yx635kvpya:
+    resolution: {integrity: sha512-k7Ch3qvs8U74aRMMRvNisxcxZFTzk8FDdvpQKXxSZ8fsD4ZwpM0MoUSqKsCXbfTvUI7MJiGxavy1YlvImPNO+Q==}
+    peerDependencies:
+      '@tanstack/react-query': ^4.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.1.1
+      '@tanstack/react-query': 4.0.10_biqbaboplfbrettd7655fr4n2y
+      '@types/use-sync-external-store': 0.0.3
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
   /@tanstack/react-query/4.0.10_biqbaboplfbrettd7655fr4n2y:
@@ -2683,6 +2707,10 @@ packages:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
     dev: true
+
+  /remove-accents/0.4.2:
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
+    dev: false
 
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}

--- a/src/components/echarts-wrapper.tsx
+++ b/src/components/echarts-wrapper.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import * as echarts from "echarts";
 import React from "react";
 
 export function EchartsWrapper(props: {
@@ -8,9 +8,6 @@ export function EchartsWrapper(props: {
 }) {
   const ref = React.useRef(null);
   const instance = React.useRef<echarts.ECharts>();
-
-  // dynamic import echarts https://github.com/remix-run/remix/issues/129
-  const { data: echarts } = usePromise(() => import("echarts"));
 
   React.useEffect(() => {
     if (!instance.current && ref.current && echarts) {
@@ -44,13 +41,4 @@ export function EchartsWrapper(props: {
   }, [echarts, props.option]);
 
   return <div ref={ref} style={props.style} />;
-}
-
-function usePromise<T>(f: () => Promise<T>) {
-  return useQuery({
-    queryKey: [usePromise.name, f.toString()],
-    queryFn: f,
-    staleTime: Infinity,
-    cacheTime: Infinity,
-  });
 }

--- a/src/components/lazy-component.tsx
+++ b/src/components/lazy-component.tsx
@@ -1,0 +1,10 @@
+import { usePromise } from "../utils/hooks";
+
+export function LazyComponent<P = {}, T = React.ComponentType<P>>(props: {
+  importer: () => Promise<T>;
+  render: (Component: T) => React.ReactNode;
+  fallback?: React.ReactNode;
+}) {
+  const query = usePromise(props.importer);
+  return <>{query.isSuccess ? props.render(query.data) : props.fallback}</>;
+}

--- a/src/routes/index.page.tsx
+++ b/src/routes/index.page.tsx
@@ -4,11 +4,9 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { chunk, minBy, sortBy, zip } from "lodash";
 import React from "react";
 import { useForm } from "react-hook-form";
-import ReactSelect, { OptionProps, components } from "react-select";
-import ReactSelectCreatable from "react-select/creatable";
-import { EchartsWrapper } from "../components/echarts-wrapper";
+import { OptionProps, components } from "react-select";
+import { LazyComponent } from "../components/lazy-component";
 import { Modal } from "../components/modal";
-import { NoSSR } from "../components/no-ssr";
 import { Spinner } from "../components/spinner";
 import {
   COUNT_TYPES,
@@ -104,30 +102,36 @@ export default function PageComponent() {
       >
         <label className="flex flex-col gap-1.5 px-4">
           <span>Ameba ID</span>
-          <NoSSR fallback={<div className="border rounded-[4px] h-[38px]" />}>
-            <ReactSelectCreatable
-              isMulti
-              placeholder="Enter IDs"
-              components={{ Option: CustomAmebaIdOption }}
-              value={amebaIds.map((value) => ({ label: value, value }))}
-              options={amebaIdOptions.map((value) => ({
-                label: value,
-                value,
-              }))}
-              onCreateOption={(created) => {
-                form.setValue("amebaIds", [...amebaIds, created]);
-                if (!amebaIdOptions.includes(created)) {
-                  setAmebaIdOptions([...amebaIdOptions, created]);
-                }
-              }}
-              onChange={(selected) => {
-                form.setValue(
-                  "amebaIds",
-                  selected.map((s) => s.value)
-                );
-              }}
-            />
-          </NoSSR>
+          <LazyComponent
+            fallback={<div className="border rounded-[4px] h-[38px]" />}
+            importer={() =>
+              import("react-select/creatable").then((lib) => lib.default)
+            }
+            render={(ReactSelectCreatable) => (
+              <ReactSelectCreatable
+                isMulti
+                placeholder="Enter IDs"
+                components={{ Option: CustomAmebaIdOption }}
+                value={amebaIds.map((value) => ({ label: value, value }))}
+                options={amebaIdOptions.map((value) => ({
+                  label: value,
+                  value,
+                }))}
+                onCreateOption={(created) => {
+                  form.setValue("amebaIds", [...amebaIds, created]);
+                  if (!amebaIdOptions.includes(created)) {
+                    setAmebaIdOptions([...amebaIdOptions, created]);
+                  }
+                }}
+                onChange={(selected) => {
+                  form.setValue(
+                    "amebaIds",
+                    selected.map((s) => s.value)
+                  );
+                }}
+              />
+            )}
+          />
         </label>
         <label className="flex flex-col gap-1.5 px-4">
           <div className="flex items-center gap-2">
@@ -136,24 +140,28 @@ export default function PageComponent() {
               <Spinner size="18px" />
             )}
           </div>
-          <NoSSR fallback={<div className="border rounded-[4px] h-[38px]" />}>
-            <ReactSelect
-              isMulti
-              isSearchable={false}
-              placeholder="Select Themes"
-              value={selectedThemes.map((t) => ({
-                label: t.theme_name,
-                value: t,
-              }))}
-              options={themeOptions}
-              onChange={(selected) => {
-                form.setValue(
-                  "selectedThemes",
-                  (selected as any[]).map((s) => s.value)
-                );
-              }}
-            />
-          </NoSSR>
+          <LazyComponent
+            fallback={<div className="border rounded-[4px] h-[38px]" />}
+            importer={() => import("react-select").then((lib) => lib.default)}
+            render={(ReactSelect) => (
+              <ReactSelect
+                isMulti
+                isSearchable={false}
+                placeholder="Select Themes"
+                value={selectedThemes.map((t) => ({
+                  label: t.theme_name,
+                  value: t,
+                }))}
+                options={themeOptions}
+                onChange={(selected) => {
+                  form.setValue(
+                    "selectedThemes",
+                    (selected as any[]).map((s) => s.value)
+                  );
+                }}
+              />
+            )}
+          />
         </label>
         <label className="flex flex-col gap-1.5 px-4">
           <span>Count type</span>
@@ -631,10 +639,20 @@ function Chart(props: {
   }, [props.countType, props.themes, isHoverDevice]);
 
   return (
-    <EchartsWrapper
-      option={option}
-      style={{ width: "100%", height: "250px" }}
-      setInstance={setChart}
+    <LazyComponent
+      fallback={<div style={{ width: "100%", height: "250px" }} />}
+      importer={() =>
+        import("../components/echarts-wrapper").then(
+          (lib) => lib.EchartsWrapper
+        )
+      }
+      render={(EchartsWrapper) => (
+        <EchartsWrapper
+          option={option}
+          style={{ width: "100%", height: "250px" }}
+          setInstance={setChart}
+        />
+      )}
     />
   );
 }

--- a/src/routes/index.page.tsx
+++ b/src/routes/index.page.tsx
@@ -177,29 +177,33 @@ export default function PageComponent() {
           </select>
         </label>
       </div>
-      {/*  */}
-      {/* chart */}
-      {/*  */}
-      <div className="relative w-full">
-        {entryQueries.some((q) => q.isLoading) && (
-          <div className="absolute right-8 top-0">
-            <Spinner size="24px" />
+      {(amebaIds.length > 0 || themeEntries.length > 0) && (
+        <>
+          {/*  */}
+          {/* chart */}
+          {/*  */}
+          <div className="relative w-full">
+            {entryQueries.some((q) => q.isLoading) && (
+              <div className="absolute right-8 top-0">
+                <Spinner size="24px" />
+              </div>
+            )}
+            <Chart
+              countType={countType}
+              themes={themeEntries}
+              setSelected={setSelected}
+            />
           </div>
-        )}
-        <Chart
-          countType={countType}
-          themes={themeEntries}
-          setSelected={setSelected}
-        />
-      </div>
-      {/*  */}
-      {/* thumbnails */}
-      {/*  */}
-      <ThumbnailList
-        themeEntries={themeEntries}
-        countType={countType}
-        selected={selected}
-      />
+          {/*  */}
+          {/* thumbnails */}
+          {/*  */}
+          <ThumbnailList
+            themeEntries={themeEntries}
+            countType={countType}
+            selected={selected}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Head } from "rakkasjs";
 import React from "react";
 import "virtual:windi.css";
@@ -8,7 +9,7 @@ export default function Layout(props: React.PropsWithChildren) {
     <>
       <Head
         title="ameblo-stats"
-        // overwritten by rakkas internally https://github.com/rakkasjs/rakkasjs/blob/114afc1842d3044940f7dc8cde11d696368bd6dc/packages/rakkasjs/src/features/pages/middleware.tsx#L480-L481
+        // TODO: overwritten by rakkas internally https://github.com/rakkasjs/rakkasjs/blob/114afc1842d3044940f7dc8cde11d696368bd6dc/packages/rakkasjs/src/features/pages/middleware.tsx#L480-L481
         // meta={[
         //   <meta charSet="utf-8" />,
         //   <meta
@@ -19,7 +20,10 @@ export default function Layout(props: React.PropsWithChildren) {
       />
       {/* hack for https://github.com/rehooks/local-storage/blob/db301e64d3db82f75775bdb477ca42feb5e3e49b/src/local-storage-events.ts#L14 */}
       <script>{`window.global = window;`}</script>
-      <Providers>{props.children}</Providers>
+      <Providers>
+        {props.children}
+        {import.meta.env.DEV && <ReactQueryDevtools />}
+      </Providers>
     </>
   );
 }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+
+export function usePromise<T>(f: () => Promise<T>) {
+  return useQuery({
+    queryKey: [usePromise.name, f.toString()],
+    queryFn: f,
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
+}


### PR DESCRIPTION
## before

https://github.com/hi-ogawa/ameblo-stats/runs/7937621937?check_suite_focus=true#step:6:11

```
rakkas: Building client (1/2)
vite v3.0.9 building for production...
transforming...
✓ 681 modules transformed.
rendering chunks...
dist/client/manifest.json                   1.30 KiB
dist/client/assets/layout.22feb5b3.js       0.44 KiB / gzip: 0.29 KiB
dist/client/assets/index.0c0f6e5c.js        36.54 KiB / gzip: 10.36 KiB
dist/client/assets/layout.ed0f47de.css      4.86 KiB / gzip: 1.58 KiB
dist/client/assets/index.5477b731.js        171.60 KiB / gzip: 55.96 KiB
dist/client/assets/index.page.7937907b.js   254.81 KiB / gzip: 85.16 KiB
dist/client/assets/index.1f644ee1.js        1006.48 KiB / gzip: 333.57 KiB
```

## after

https://github.com/hi-ogawa/ameblo-stats/runs/7937856415?check_suite_focus=true#step:6:11

```
rakkas: Building client (1/2)
vite v3.0.9 building for production...
transforming...
✓ 683 modules transformed.
rendering chunks...
dist/client/manifest.json                            2.69 KiB
dist/client/assets/index.de267a32.js                 36.54 KiB / gzip: 10.36 KiB
dist/client/assets/react-select.esm.33aef94b.js      2.04 KiB / gzip: 0.97 KiB
dist/client/assets/layout.41addbf9.js                0.45 KiB / gzip: 0.30 KiB
dist/client/assets/react-select.esm.f856eee6.js      0.92 KiB / gzip: 0.47 KiB
dist/client/assets/layout.ed0f47de.css               4.86 KiB / gzip: 1.58 KiB
dist/client/assets/Select-54ac8379.esm.3b7971f7.js   41.13 KiB / gzip: 13.54 KiB
dist/client/assets/index.b9df385f.js                 171.61 KiB / gzip: 55.97 KiB
dist/client/assets/index.page.ccbbb72e.js            212.72 KiB / gzip: 72.04 KiB
dist/client/assets/echarts-wrapper.f6e4a486.js       1007.03 KiB / gzip: 333.89 KiB
```